### PR TITLE
Implement owner and payer functions

### DIFF
--- a/parameterized/proposal_inverter.py
+++ b/parameterized/proposal_inverter.py
@@ -41,7 +41,7 @@ class ProposalInverter(Wallet):
     # Parameters
     min_stake = pm.Number(5, doc="minimum funds that a broker must stake to join")
     current_epoch = pm.Number(0, doc="number of epochs that have passed")
-    cancel_epoch = pm.Number(0, doc="epoch where cancellation conditions have been met")
+    cancel_epoch = pm.Number(0, doc="last epoch where minimum conditions were been met")
     epoch_length = pm.Number(60*60*24, doc="length of one epoch, measured in seconds")
     min_epochs = pm.Number(28, doc="minimum number of epochs that must pass for a broker to exit and take their stake")
     allocation_per_epoch = pm.Number(10, doc="funds allocated to all brokers per epoch")
@@ -50,7 +50,6 @@ class ProposalInverter(Wallet):
     max_brokers = pm.Number(5, doc="maximum number of brokers that can join")
     buffer_period = pm.Number(5, doc="minimum number of epochs for a condition to trigger the cancellation of the proposal inverter")
     broker_agreements = pm.Dict(dict(), doc="maps each broker's public key to their broker agreement")
-    owner = str()
     
     def __init__(self, owner: Wallet, initial_funds: float, **params):
         super(ProposalInverter, self).__init__(**params)
@@ -157,18 +156,15 @@ class ProposalInverter(Wallet):
             for public, broker_agreement in self.broker_agreements.items():
                 broker_agreement.allocated_funds += self.get_broker_claimable_funds()
 
-            self.current_epoch += 1
-
-        if self.number_of_brokers() < self.min_brokers and self.get_horizon() < self.min_horizon:
             # Use cancel_epoch to record when the cancellation condition was triggered
-            # If cancel_epoch = 0 & cancellation conditions are met, then update cancel_epoch
-            if self.cancel_epoch == 0: 
+            if self.number_of_brokers() >= self.min_brokers or self.get_horizon() >= self.min_horizon:
                 self.cancel_epoch = self.current_epoch
-            elif (self.current_epoch - self.cancel_epoch) <= self.buffer_period:
-                return
+
             # If the forced cancellation conditions are met for a period longer than the buffer period, trigger the cancel function
-            elif (self.current_epoch - self.cancel_epoch) > self.buffer_period:
+            if (self.current_epoch - self.cancel_epoch) > self.buffer_period:
                 self.cancel()
+
+            self.current_epoch += 1
 
     def number_of_brokers(self):
         return len(self.committed_brokers)
@@ -221,6 +217,14 @@ class ProposalInverter(Wallet):
 
         for public_key, broker_agreement in self.broker_agreements.items():
             broker_agreement.allocated_funds += broker_agreement.initial_stake + (self.funds - total_stake - total_allocated_funds) / self.number_of_brokers()
+
+        # If there are no brokers attached to the proposal inverter, return funds to owner
+        self.broker_agreements[self.owner_address] = BrokerAgreement(
+            epoch_joined=self.current_epoch,
+            initial_stake=0,
+            allocated_funds=self.funds - self.get_allocated_funds(),
+            total_claimed=0           
+        )
     
     
 class Owner(Wallet):
@@ -236,7 +240,7 @@ class Owner(Wallet):
         )
         return params
     
-    def deploy(self, initial_funds, agreement_contract_params={}):
+    def deploy(self, initial_funds, **agreement_contract_params):
         """
         An actor within the ecosystem can deploy a new agreement contract by specifying which proposal the agreement 
         supports, setting the parameters of the smart contract providing initial funds, and providing any (unenforced) 
@@ -245,18 +249,18 @@ class Owner(Wallet):
         and that B=∅.
         """
         params = self._default_agreement_contract_params()
-        params.update(agreement_contaract_params)
+        params.update(agreement_contract_params)
             
         # Check imposed restrictions (whether horizon is greater than the min horizon)
-        horizon = initial_funds / agreement_contract_params['allocation_per_epoch']
-        if horizon < agreement_contract_params['min_horizon']:
+        horizon = initial_funds / params['allocation_per_epoch']
+        if horizon < params['min_horizon']:
             print("The Horizon is lower than the mininum required horizon")
             return None
 
         agreement_contract = ProposalInverter(
                 owner = self,
                 initial_funds = initial_funds,
-                **agreement_contract_params,
+                **params,
             )
         
         return agreement_contract

--- a/parameterized/proposal_inverter.py
+++ b/parameterized/proposal_inverter.py
@@ -148,17 +148,17 @@ class ProposalInverter(Wallet):
     def iter_epoch(self, n_epochs=1):
         """
         Iterates to the next epoch and updates the total claimable funds for each broker.
+
+        There may conditions under which any address may trigger the cancel but these conditions should be 
+        indicative of a failure on the part of the payer. An example policy would be to allow forced cancel 
+        when n < nmin and H < H min, and possibly only if this is the case more multiple epochs.
         """
         for epoch in range(n_epochs):
             for public, broker_agreement in self.broker_agreements.items():
                 broker_agreement.allocated_funds += self.get_broker_claimable_funds()
 
             self.current_epoch += 1
-        """
-        There may conditions under which any address may trigger the cancel but these conditions should be 
-        indicative of a failure on the part of the payer. An example policy would be to allow forced cancel 
-        when n < nmin and H < H min, and possibly only if this is the case more multiple epochs.
-        """
+
         if self.number_of_brokers() < self.min_brokers and self.get_horizon() < self.min_horizon:
             # Use cancel_epoch to record when the cancellation condition was triggered
             # If cancel_epoch = 0 & cancellation conditions are met, then update cancel_epoch
@@ -244,8 +244,8 @@ class Owner(Wallet):
         of this draft, it is assumed that the contract is initialized with some quantity of funds F such that H>Hmin 
         and that B=∅.
         """
-        if not agreement_contract_params:
-            agreement_contract_params = self._default_agreement_contract_params()
+        params = self._default_agreement_contract_params()
+        params.update(agreement_contaract_params)
             
         # Check imposed restrictions (whether horizon is greater than the min horizon)
         horizon = initial_funds / agreement_contract_params['allocation_per_epoch']

--- a/parameterized/proposal_inverter.py
+++ b/parameterized/proposal_inverter.py
@@ -199,8 +199,12 @@ class ProposalInverter(Wallet):
 
         when the contract is self-destructed.
         """    
-        pass
-    
+        total_stake = 0
+        total_allocated_funds = self.get_allocated_funds()
+        for public_key, broker_agreement in self.broker_agreements.items():
+            total_stake += broker_agreement.initial_stake 
+        for public_key, broker_agreement in self.broker_agreements.items():
+            broker_agreement.allocated_funds += broker_agreement.initial_stake + (self.funds - total_stake - total_allocated_funds) / self.number_of_brokers()
     
     
 class Owner(Wallet):
@@ -252,15 +256,8 @@ class Owner(Wallet):
         # This function relies on there being given a broker_pool that keeps track of brokers
         
         # Calculate the total allocated funds & total stake for proper calculation
-        total_stake = 0
-        total_allocated_funds = agreement_contract.get_allocated_funds()
-        for public_key, broker_agreement in inverter.broker_agreements.items():
-            total_stake += broker_agreement.initial_stake 
-        for public_key, broker_agreement in agreement_contract.broker_agreements.items():
-            broker_agreement.allocated_funds += broker_agreement.initial_stake + (agreement_contract.funds - total_stake - total_allocated_funds) / agreement_contract.number_of_brokers()
+        agreement_contract.cancel()
         for broker_key in broker_pool:
             broker_pool[broker_key] = agreement_contract.claim_broker_funds(broker_pool[broker_key])
-            
-        agreement_contract.cancel()
         return broker_pool
 

--- a/parameterized/proposal_inverter.py
+++ b/parameterized/proposal_inverter.py
@@ -133,7 +133,7 @@ class ProposalInverter(Wallet):
         if broker_agreement is None:
             print("Broker is not part of this proposal")
         else:
-            if self.current_epoch - broker_agreement.epoch_joined >= self.min_epochs and self.get_horizon() < self.min_horizon:
+            if self.current_epoch - broker_agreement.epoch_joined >= self.min_epochs:
                 stake = broker_agreement.initial_stake
                 broker.funds += stake
                 self.funds -= stake

--- a/parameterized/test_broker.py
+++ b/parameterized/test_broker.py
@@ -11,6 +11,55 @@ def test_deploy_proposal_inverter():
     assert inverter.number_of_brokers() == 0
 
 
+def test_remove_proposal_inverter():
+    # Deploy proposal inverter
+    owner = Owner()
+    owner.funds = 1000
+    params = owner._default_agreement_contract_params()
+    inverter = owner.deploy(500, params)
+    
+    # Add brokers (each with a different initial stake)
+    broker1 = Broker()
+    broker2 = Broker()
+    broker1.funds = 100
+    broker2.funds = 100
+    broker1 = inverter.add_broker(broker1, 50)
+    broker2 = inverter.add_broker(broker2, 100)
+    
+    # Check total funds: 500(owner initial amount) + 50 (broker1 stake) + 100 (broker2 stake)
+    assert inverter.funds == 650
+    
+    inverter.iter_epoch(30)
+    
+    # Create a prototype broker pool, which is a dictionary where the key is the broker public key
+    # and the value is the broker object
+    keyarray = []
+    for public_key, broker_agreement in inverter.broker_agreements.items():
+        keyarray.append(public_key)
+    broker_pool = dict()
+    broker_pool[keyarray[0]] = broker1
+    broker_pool[keyarray[1]] = broker2
+    
+    """
+    If we have a proposal inverter deployed at 500 and 2 brokers enter the agreement, 
+    broker 1 (stake=50) & broker2 (stake=100), enter at epoch=0, at epoch=30, 
+    each of their claimable funds would be 150. 
+    Broker 1 should receive: 50 + 150 + (650-1(150)-50-100)/2 = 50 + 150 +100 =300 
+    Broker 2 should receive: 100 + 150 + (650-1(150)-50-100)/2 = 50 + 150 +100 =350
+    """
+    for public_key, broker_agreement in inverter.broker_agreements.items():
+        assert broker_agreement.allocated_funds == 150
+        
+    # Call the cancel function which returns the updated broker pool
+    broker_pool = owner.cancel(inverter, broker_pool)
+    
+    # Broker1 funds = 300 + 50(broker1's current funds)
+    assert broker1.funds == 350
+    
+    # Broker2 funds = 350 + 0(broker2's current funds)
+    assert broker2.funds == 350    
+    
+    
 def test_add_broker():
     # Deploy proposal inverter
     owner = Owner()

--- a/parameterized/test_owner.py
+++ b/parameterized/test_owner.py
@@ -1,0 +1,58 @@
+from proposal_inverter import Owner, Broker
+
+
+def test_deploy_proposal_inverter():
+    owner = Owner()
+    owner.funds = 1000
+    inverter = owner.deploy(500)
+
+    assert inverter.funds == 500
+    assert inverter.current_epoch == 0
+    assert inverter.number_of_brokers() == 0
+
+
+def test_remove_proposal_inverter():
+    # Deploy proposal inverter
+    owner = Owner()
+    owner.funds = 1000
+    inverter = owner.deploy(500)
+    
+    # Add brokers (each with a different initial stake)
+    broker1 = Broker()
+    broker2 = Broker()
+    broker1.funds = 100
+    broker2.funds = 100
+    broker1 = inverter.add_broker(broker1, 50)
+    broker2 = inverter.add_broker(broker2, 100)
+    
+    # Check total funds: 500(owner initial amount) + 50 (broker1 stake) + 100 (broker2 stake)
+    assert inverter.funds == 650
+    
+    inverter.iter_epoch(30)
+    
+    # Create a prototype broker pool, which is a dictionary where the key is the broker public key
+    # and the value is the broker object
+    broker_pool = {
+        broker1.public: broker1,
+        broker2.public: broker2,
+    }
+    
+    """
+    If we have a proposal inverter deployed at 500 and 2 brokers enter the agreement, 
+    broker 1 (stake=50) & broker2 (stake=100), enter at epoch=0, at epoch=30, 
+    each of their claimable funds would be 150. 
+    Broker 1 should receive: 50 + 150 + (650-1(150)-50-100)/2 = 50 + 150 +100 =300 
+    Broker 2 should receive: 100 + 150 + (650-1(150)-50-100)/2 = 50 + 150 +100 =350
+    """
+    for public_key, broker_agreement in inverter.broker_agreements.items():
+        assert broker_agreement.allocated_funds == 150
+        
+    # Call the cancel function which returns the updated broker pool
+    broker_pool = owner.cancel(inverter, broker_pool)
+    
+    # Broker1 funds = 300 + 50(broker1's current funds)
+    assert broker1.funds == 350
+    
+    # Broker2 funds = 350 + 0(broker2's current funds)
+    assert broker2.funds == 350
+

--- a/parameterized/test_proposal_inverter.py
+++ b/parameterized/test_proposal_inverter.py
@@ -1,61 +1,4 @@
 from proposal_inverter import Owner, Broker, ProposalInverter
-
-
-def test_deploy_proposal_inverter():
-    owner = Owner()
-    owner.funds = 1000
-    inverter = owner.deploy(500)
-
-    assert inverter.funds == 500
-    assert inverter.current_epoch == 0
-    assert inverter.number_of_brokers() == 0
-
-
-def test_remove_proposal_inverter():
-    # Deploy proposal inverter
-    owner = Owner()
-    owner.funds = 1000
-    params = owner._default_agreement_contract_params()
-    inverter = owner.deploy(500, params)
-    
-    # Add brokers (each with a different initial stake)
-    broker1 = Broker()
-    broker2 = Broker()
-    broker1.funds = 100
-    broker2.funds = 100
-    broker1 = inverter.add_broker(broker1, 50)
-    broker2 = inverter.add_broker(broker2, 100)
-    
-    # Check total funds: 500(owner initial amount) + 50 (broker1 stake) + 100 (broker2 stake)
-    assert inverter.funds == 650
-    
-    inverter.iter_epoch(30)
-    
-    # Create a prototype broker pool, which is a dictionary where the key is the broker public key
-    # and the value is the broker object
-    broker_pool = {
-        broker1.public: broker1,
-        broker2.public: broker2,
-    }
-    
-    """
-    If we have a proposal inverter deployed at 500 and 2 brokers enter the agreement, 
-    broker 1 (stake=50) & broker2 (stake=100), enter at epoch=0, at epoch=30, 
-    each of their claimable funds would be 150. 
-    Broker 1 should receive: 50 + 150 + (650-1(150)-50-100)/2 = 50 + 150 +100 =300 
-    Broker 2 should receive: 100 + 150 + (650-1(150)-50-100)/2 = 50 + 150 +100 =350
-    """
-    for public_key, broker_agreement in inverter.broker_agreements.items():
-        assert broker_agreement.allocated_funds == 150
-        
-    # Call the cancel function which returns the updated broker pool
-    broker_pool = owner.cancel(inverter, broker_pool)
-    
-    # Broker1 funds = 300 + 50(broker1's current funds)
-    assert broker1.funds == 350
-    
-    # Broker2 funds = 350 + 0(broker2's current funds)
-    assert broker2.funds == 350    
     
     
 def test_add_broker():
@@ -175,4 +118,56 @@ def test_get_allocated_funds():
     inverter.iter_epoch(20)
 
     assert inverter.get_allocated_funds() == 300
+
+
+def test_pay():
+    # Deploy proposal inverter
+    owner = Owner()
+    owner.funds = 1000
+    inverter = owner.deploy(500)
+
+    payer = Broker()
+    payer.funds = 100
+
+    payer = inverter.pay(payer, 25)
+
+    assert payer.funds == 75
+    assert inverter.funds == 525
+
+    
+def test_cancel():
+    # Deploy proposal inverter
+    owner = Owner()
+    owner.funds = 1000
+    inverter = owner.deploy(500)
+    
+    # Add brokers (each with a different initial stake)
+    broker1 = Broker()
+    broker2 = Broker()
+    broker1.funds = 100
+    broker2.funds = 100
+    broker1 = inverter.add_broker(broker1, 50)
+    broker2 = inverter.add_broker(broker2, 100)
+    
+    # Check total funds: 500(owner initial amount) + 50 (broker1 stake) + 100 (broker2 stake)
+    assert inverter.funds == 650
+    
+    inverter.iter_epoch(30)
+    
+    # Cancel the proposal inverter
+    inverter.cancel()
+
+    # Each broker makes their claim
+    broker1 = inverter.claim_broker_funds(broker1)
+    broker2 = inverter.claim_broker_funds(broker2)
+        
+    # Broker1 funds = 300 + 50(broker1's current funds)
+    assert broker1.funds == 350
+    
+    # Broker2 funds = 350 + 0(broker2's current funds)
+    assert broker2.funds == 350
+
+    # End state of proposal inverter
+    assert inverter.funds == 0
+    assert inverter.get_allocated_funds() == 0
 

--- a/parameterized/test_proposal_inverter.py
+++ b/parameterized/test_proposal_inverter.py
@@ -33,12 +33,10 @@ def test_remove_proposal_inverter():
     
     # Create a prototype broker pool, which is a dictionary where the key is the broker public key
     # and the value is the broker object
-    keyarray = []
-    for public_key, broker_agreement in inverter.broker_agreements.items():
-        keyarray.append(public_key)
-    broker_pool = dict()
-    broker_pool[keyarray[0]] = broker1
-    broker_pool[keyarray[1]] = broker2
+    broker_pool = {
+        broker1.public: broker1,
+        broker2.public: broker2,
+    }
     
     """
     If we have a proposal inverter deployed at 500 and 2 brokers enter the agreement, 

--- a/parameterized/test_proposal_inverter.py
+++ b/parameterized/test_proposal_inverter.py
@@ -42,6 +42,10 @@ def test_add_broker(inverter, broker1):
 
 
 def test_claim_broker_funds(inverter, broker1, broker2):
+    """
+    Test that the brokers receive the correct amounts of funds when they claim their funds before the minimum number of
+    epochs.
+    """
     # Add broker to proposal inverter
     broker1 = inverter.add_broker(broker1, 50)
 
@@ -74,6 +78,10 @@ def test_claim_broker_funds(inverter, broker1, broker2):
 
     
 def test_remove_broker(inverter, broker1, broker2):
+    """
+    Ensure that when a broker leaves the proposal inverter, they receive their stake if they have stayed for the minimum
+    number of epochs.
+    """
     # Add brokers
     broker1 = inverter.add_broker(broker1, 100)
     broker2 = inverter.add_broker(broker2, 100)
@@ -81,14 +89,22 @@ def test_remove_broker(inverter, broker1, broker2):
     assert inverter.number_of_brokers() == 2
     assert inverter.funds == 700
 
-    # Remove a broker while over the minimum horizon
-    inverter.iter_epoch(30)
+    inverter.iter_epoch(20)
 
     broker1 = inverter.remove_broker(broker1)
 
     assert inverter.number_of_brokers() == 1
-    assert inverter.funds == 550
-    assert broker1.funds == 150
+    assert inverter.funds == 600
+    assert broker1.funds == 100
+
+    # Remove a broker while over the minimum number of epochs
+    inverter.iter_epoch(10)
+
+    broker2 = inverter.remove_broker(broker2)
+
+    assert inverter.number_of_brokers() == 0
+    assert inverter.funds == 300
+    assert broker2.funds == 300
 
     
 def test_get_allocated_funds(inverter, broker1, broker2):


### PR DESCRIPTION
The updates cover three major areas.

### Implementing the owner functions

This includes the deploy and cancel functions

- When cancelling the proposal inverter, the funds are all allocated to the broker agreements so that when they make their claim, they will receive all unclaimed funds in addition to their share of the remaining funds. 
- Cancel also covers the edge case when there are no brokers left in the proposal inverter, in which case the funds are assigned to the owner
- Cancelling also assumes that the pool of brokers is managed elsewhere and is out of scope of the proposal inverter itself
- When the epoch is increased, the proposal inverter checks the conditions for a forced cancel, which occurs if funds are low and if there are not enough brokers. The cancel function is only triggered when these conditions are met for multiple consecutive epochs, the length of which is defined by the `cancel_epoch` parameter, which acts as the buffer period.
- Three test cases for the forced cancel are outlined in the unit tests for the proposal inverter

### Implementing the payer function

There is only one payer function in which an entity can add funds to the proposal inverter. This is not tracked or logged, but simply increases the horizon of the proposal inverter.

### Unit Tests

The unit tests were divided into tests for the `ProposalInverter` itself, and for the `Qwner` class. The previous tests were also refactored to use a simple pytest fixture to deploy the proposal inverter and create the brokers.